### PR TITLE
Smol fix

### DIFF
--- a/src/multiplexer/CGIManager.cpp
+++ b/src/multiplexer/CGIManager.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   CGIManager.cpp                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tsuchen <tsuchen@student.42.fr>            +#+  +:+       +#+        */
+/*   By: bthomas <bthomas@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/30 12:10:49 by bthomas           #+#    #+#             */
-/*   Updated: 2024/10/03 18:37:50 by tsuchen          ###   ########.fr       */
+/*   Updated: 2024/10/07 11:23:52 by bthomas          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,7 +52,7 @@ void CGIManager::deleteFromCGI(int pipefd) {
 bool CGIManager::isResponseComplete(int pipefd) {
 	if (!isInManager(pipefd))
 		return true;
-	std::string buff = _cgiProcesses[pipefd]->output;
+	std::string & buff = _cgiProcesses.at(pipefd)->output;
 	std::string::size_type pos = buff.find("\r\n\r\n");
 	if (pos == std::string::npos)
 		return false;

--- a/src/multiplexer/CGIManager.cpp
+++ b/src/multiplexer/CGIManager.cpp
@@ -6,7 +6,7 @@
 /*   By: bthomas <bthomas@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/30 12:10:49 by bthomas           #+#    #+#             */
-/*   Updated: 2024/10/07 11:23:52 by bthomas          ###   ########.fr       */
+/*   Updated: 2024/10/07 11:39:03 by bthomas          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,7 +52,7 @@ void CGIManager::deleteFromCGI(int pipefd) {
 bool CGIManager::isResponseComplete(int pipefd) {
 	if (!isInManager(pipefd))
 		return true;
-	std::string & buff = _cgiProcesses.at(pipefd)->output;
+	const std::string & buff = _cgiProcesses.at(pipefd)->output;
 	std::string::size_type pos = buff.find("\r\n\r\n");
 	if (pos == std::string::npos)
 		return false;

--- a/src/multiplexer/EventHandler.cpp
+++ b/src/multiplexer/EventHandler.cpp
@@ -6,7 +6,7 @@
 /*   By: bthomas <bthomas@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/24 12:20:55 by bthomas           #+#    #+#             */
-/*   Updated: 2024/10/07 11:22:01 by bthomas          ###   ########.fr       */
+/*   Updated: 2024/10/07 11:38:09 by bthomas          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -139,12 +139,12 @@ void EventHandler::handleNewConnection(Server & s) {
 }
 
 bool EventHandler::isMultiPartReq(int clientFd) {
-	std::string & req = _clients.at(clientFd)->_requestBuffer;
+	const std::string & req = _clients.at(clientFd)->_requestBuffer;
 	return req.find("Content-Type: multipart") != std::string::npos;
 }
 
 bool EventHandler::isMultiPartReqFinished(int clientFd) {
-	std::string & req = _clients.at(clientFd)->_requestBuffer;
+	const std::string & req = _clients.at(clientFd)->_requestBuffer;
 	std::string::size_type boundaryPos = req.find("boundary=");
 	if (boundaryPos == std::string::npos) {
 		return false;
@@ -157,7 +157,7 @@ bool EventHandler::isMultiPartReqFinished(int clientFd) {
 
 bool EventHandler::isResponseComplete(int clientFd) {
 	// check header completion
-	std::string & buff = _clients.at(clientFd)->_requestBuffer;
+	const std::string & buff = _clients.at(clientFd)->_requestBuffer;
 	std::string::size_type headerEnd = getHeaderEndPos(clientFd);
 	if (headerEnd == std::string::npos) {
 		return false;
@@ -183,7 +183,7 @@ bool EventHandler::isResponseComplete(int clientFd) {
 }
 
 std::string::size_type EventHandler::getHeaderEndPos(int clientFd) {
-	std::string & reqBuffer = _clients.at(clientFd)->_requestBuffer;
+	const std::string & reqBuffer = _clients.at(clientFd)->_requestBuffer;
 	std::string::size_type headerEnd = reqBuffer.find("\r\n\r\n");
 	if (headerEnd == std::string::npos) {
 		headerEnd = reqBuffer.find("\n\n");
@@ -198,7 +198,7 @@ std::string::size_type EventHandler::getHeaderEndPos(int clientFd) {
 }
 
 size_t EventHandler::getContentSize(int clientFd) {
-	std::string &req = _clients.at(clientFd)->_requestBuffer;
+	const std::string &req = _clients.at(clientFd)->_requestBuffer;
 	std::string::size_type sizePos = req.find("Content-Length:");
 	if (sizePos == std::string::npos) {
 		return 0;

--- a/src/multiplexer/EventHandler.cpp
+++ b/src/multiplexer/EventHandler.cpp
@@ -6,7 +6,7 @@
 /*   By: bthomas <bthomas@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/24 12:20:55 by bthomas           #+#    #+#             */
-/*   Updated: 2024/10/07 10:48:02 by bthomas          ###   ########.fr       */
+/*   Updated: 2024/10/07 11:22:01 by bthomas          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -139,12 +139,12 @@ void EventHandler::handleNewConnection(Server & s) {
 }
 
 bool EventHandler::isMultiPartReq(int clientFd) {
-	std::string req = _clients.at(clientFd)->_requestBuffer;
+	std::string & req = _clients.at(clientFd)->_requestBuffer;
 	return req.find("Content-Type: multipart") != std::string::npos;
 }
 
 bool EventHandler::isMultiPartReqFinished(int clientFd) {
-	std::string req = _clients.at(clientFd)->_requestBuffer;
+	std::string & req = _clients.at(clientFd)->_requestBuffer;
 	std::string::size_type boundaryPos = req.find("boundary=");
 	if (boundaryPos == std::string::npos) {
 		return false;
@@ -157,7 +157,7 @@ bool EventHandler::isMultiPartReqFinished(int clientFd) {
 
 bool EventHandler::isResponseComplete(int clientFd) {
 	// check header completion
-	std::string buff = _clients.at(clientFd)->_requestBuffer;
+	std::string & buff = _clients.at(clientFd)->_requestBuffer;
 	std::string::size_type headerEnd = getHeaderEndPos(clientFd);
 	if (headerEnd == std::string::npos) {
 		return false;
@@ -183,7 +183,7 @@ bool EventHandler::isResponseComplete(int clientFd) {
 }
 
 std::string::size_type EventHandler::getHeaderEndPos(int clientFd) {
-	std::string reqBuffer = _clients.at(clientFd)->_requestBuffer;
+	std::string & reqBuffer = _clients.at(clientFd)->_requestBuffer;
 	std::string::size_type headerEnd = reqBuffer.find("\r\n\r\n");
 	if (headerEnd == std::string::npos) {
 		headerEnd = reqBuffer.find("\n\n");

--- a/src/multiplexer/EventHandler_chunks.cpp
+++ b/src/multiplexer/EventHandler_chunks.cpp
@@ -6,7 +6,7 @@
 /*   By: bthomas <bthomas@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/04 10:54:25 by bthomas           #+#    #+#             */
-/*   Updated: 2024/10/04 15:21:48 by bthomas          ###   ########.fr       */
+/*   Updated: 2024/10/07 11:23:05 by bthomas          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,12 +32,12 @@ double CRLF (or \n\n) signifies end of header;
 */
 
 bool EventHandler::isHeaderChunked(int clientFd) {
-	std::string request = _clients[clientFd]->_requestBuffer;
+	std::string & request = _clients[clientFd]->_requestBuffer;
 	return (request.find("Transfer-Encoding: chunked") != std::string::npos);
 }
 
 bool EventHandler::isChunkReqFinished(int clientFd) {
-	std::string request = _clients[clientFd]->_requestBuffer;
+	std::string & request = _clients[clientFd]->_requestBuffer;
 	return (request.find("0\r\n\r\n") != std::string::npos);
 }
 
@@ -68,7 +68,7 @@ std::string::size_type EventHandler::getChunkSize(std::string::size_type & chunk
 }
 
 void EventHandler::cleanChunkedReq(int clientFd) {
-	std::string request = _clients[clientFd]->_requestBuffer;
+	std::string & request = _clients[clientFd]->_requestBuffer;
 	std::string decodedContent;
 	std::string::size_type chunkSize;
 	std::string::size_type headerEnd, chunkStart, chunkEnd;

--- a/src/multiplexer/EventHandler_chunks.cpp
+++ b/src/multiplexer/EventHandler_chunks.cpp
@@ -6,7 +6,7 @@
 /*   By: bthomas <bthomas@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/04 10:54:25 by bthomas           #+#    #+#             */
-/*   Updated: 2024/10/07 11:23:05 by bthomas          ###   ########.fr       */
+/*   Updated: 2024/10/07 11:39:42 by bthomas          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,12 +32,12 @@ double CRLF (or \n\n) signifies end of header;
 */
 
 bool EventHandler::isHeaderChunked(int clientFd) {
-	std::string & request = _clients[clientFd]->_requestBuffer;
+	const std::string & request = _clients[clientFd]->_requestBuffer;
 	return (request.find("Transfer-Encoding: chunked") != std::string::npos);
 }
 
 bool EventHandler::isChunkReqFinished(int clientFd) {
-	std::string & request = _clients[clientFd]->_requestBuffer;
+	const std::string & request = _clients[clientFd]->_requestBuffer;
 	return (request.find("0\r\n\r\n") != std::string::npos);
 }
 


### PR DESCRIPTION
changes strings to references of strings where possible, and changed one array access to .at()